### PR TITLE
Fixed scrolling within a ViewPager

### DIFF
--- a/lib/src/main/java/it/moondroid/coverflow/components/ui/containers/FeatureCoverFlow.java
+++ b/lib/src/main/java/it/moondroid/coverflow/components/ui/containers/FeatureCoverFlow.java
@@ -1056,6 +1056,15 @@ public class FeatureCoverFlow extends EndlessLoopAdapterContainer implements Vie
         final float xf = ev.getX();
         final float yf = ev.getY();
         final RectF frame = mTouchRect;
+		
+        switch (action){
+            case MotionEvent.ACTION_DOWN:
+                getParent().requestDisallowInterceptTouchEvent(true);
+                break;
+            case MotionEvent.ACTION_UP:
+                getParent().requestDisallowInterceptTouchEvent(false);
+                break;
+        }
                 
         if (action == MotionEvent.ACTION_DOWN) {
             if (mMotionTarget != null) {


### PR DESCRIPTION
In case of CoverFlow view being located within a ViewPager the scrolling will not be allowed. By disable-ing the parent scroll we enable cover flow scrolling.